### PR TITLE
fix empty request body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,7 @@ const componentV3 = async file => {
 
   try {
     response = await v3Client.send(
-      new DetectTextCommand({ Image: { Bytes: file } })
+      new DetectTextCommand({ Image: { Bytes: new Uint8Array(file) } })
     );
   } catch (e) {
     error = e;


### PR DESCRIPTION
According to [service definition](https://github.com/aws/aws-sdk-js-v3/blob/6b3bafa35eaafd7128353870bbeedb74279a8457/clients/client-rekognition/models/index.ts#L2352), the `Image` can only be `Uint8Array` type. You need to convert the type before sending the request.